### PR TITLE
NOTICKET: Update module to support managed policies too

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,13 @@ module "inline_role" {
 |------|-------------|:----:|:-------:|:--------:|
 | role_name | Friendly name of the role. If omitted, Terraform will assign a random, unique name | `string` | `""` | no |
 | role_path | Path to the role. | string | `/` | no |
+| description | Description of the role. | string | `"` | no |
 | create_instance_profile | Controls whether the instance profile is created. | boolean | `false` | no |
 | assume_role_policy_file | Tempalte file with the policy that grants an entity permission to assume the role. | string | `null` | yes |
 | assume_role_policy_vars | Variables to inject into `assume_role_policy_file` | `map(any)` | `{}` | no |
 | inline_policies | Map defining an exclusive set of IAM inline policies associated with the IAM role. | `map(any)` | `{}` | no |
-| tags | Tags for all resources managed by this module | `map(string)` | `{}` | no |
+| managed_policy_arns | List of exclusive IAM managed policy ARNs to attach to the IAM role. If this attribute is not configured. | `list(string)` | `[]` | no |
+| tags | Tags for all resources managed by this module. | `map(string)` | `{}` | no |
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ module "inline_role" {
 | assume_role_policy_file | Tempalte file with the policy that grants an entity permission to assume the role. | string | `null` | yes |
 | assume_role_policy_vars | Variables to inject into `assume_role_policy_file` | `map(any)` | `{}` | no |
 | inline_policies | Map defining an exclusive set of IAM inline policies associated with the IAM role. | `map(any)` | `{}` | no |
-| managed_policy_arns | List of exclusive IAM managed policy ARNs to attach to the IAM role. If this attribute is not configured. | `list(string)` | `[]` | no |
+| managed_policy_arns | List of exclusive IAM managed policy ARNs to attach to the IAM role. If this attribute is not configured, Terraform will ignore policy attachments to this resource." | `list(string)` | `[]` | no |
 | tags | Tags for all resources managed by this module. | `map(string)` | `{}` | no |
 
 ### Outputs

--- a/modules/inline-role/main.tf
+++ b/modules/inline-role/main.tf
@@ -1,8 +1,9 @@
 data "aws_caller_identity" "current" {}
 
 resource "aws_iam_role" "iam_role" {
-  name = var.role_name
-  path = var.role_path
+  name        = var.role_name
+  path        = var.role_path
+  description = var.description
 
   assume_role_policy = templatefile(var.assume_role_policy_file, merge(
     { account_id = data.aws_caller_identity.current.account_id },
@@ -17,6 +18,8 @@ resource "aws_iam_role" "iam_role" {
       policy = templatefile(inline_policy.value.file, inline_policy.value.vars)
     }
   }
+
+  managed_policy_arns = var.managed_policy_arns
 
   tags = var.tags
 

--- a/modules/inline-role/variables.tf
+++ b/modules/inline-role/variables.tf
@@ -9,6 +9,12 @@ variable "role_path" {
   description = "(optional, default: /) Role path"
 }
 
+variable "description" {
+  type        = string
+  description = "Description of the role."
+  default     = ""
+}
+
 variable "create_instance_profile" {
   type        = bool
   default     = false
@@ -33,6 +39,12 @@ variable "inline_policies" {
   }))
   default     = {}
   description = "(optional, default: {}) Inline policies"
+}
+
+variable "managed_policy_arns" {
+  type        = list(string)
+  description = "Set of exclusive IAM managed policy ARNs to attach to the IAM role. If this attribute is not configured, Terraform will ignore policy attachments to this resource."
+  default     = []
 }
 
 variable "tags" {


### PR DESCRIPTION
Previously, with the in-line role module, you were only able to create a role with inline policies only, so I added the managed_policies_arn attribute so apart from the inline policy you can attach managed/custom policies previously created.